### PR TITLE
SCRUM-16 docs: add notes about Internship model validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ We will send you an email to choose a Real-World project. If you face any diffic
 * Adherence to Git best practices and practical contributions.
 * Successful implementation, deploymentand CI/CD pipeline.
 * Problem-solving skills and the ability to go beyond basic requirements.
+
+* Linked to SCRUM-16: notes about Internship model validations


### PR DESCRIPTION
Links to Jira subtask SCRUM-16. Adds notes about Internship model validations.
